### PR TITLE
Fix apostrophe

### DIFF
--- a/tumblrtags.html
+++ b/tumblrtags.html
@@ -7,7 +7,8 @@
 
 </script>
 
-<h1>A Heading for your Tags Page</h1>
-
-<!-- This div is where the tag cloud will be loaded -->
-<div id="taggggs"></div>
+<!-- Tumblr needs the div to be wrapped in paragraph tags to load it correctly. --> 
+<p>
+  <!-- This empty div is where the tags will be loaded -->
+  <div id="taggggs"></div>
+</p>

--- a/tumblrtags.js
+++ b/tumblrtags.js
@@ -140,7 +140,7 @@ function generateFlowers(tags)
 		
 		tag_url = "/tagged/" + sanitizeTagForURL(t);
 		
-		flower += "<li class='tagitem'><a href='" + tag_url + "' class='" + frequency + "'>"+ t + " " + number + "</a></li>";
+		flower += "<li class='tagitem'><a href='" + tag_url + "' class='" + frequency + "'>"+ t + "" + " (" + number + ") </a></li>";
 	}
 	flower += "</ul>";	
 	

--- a/tumblrtags.js
+++ b/tumblrtags.js
@@ -89,6 +89,7 @@ function getTags(user_url)
 	}
 }
 
+//adjust the tag name so that it will work as a URL for that tag
 function sanitizeTagForURL(tag_name)
 {
 	sanitized_tag_name = tag_name;

--- a/tumblrtags.js
+++ b/tumblrtags.js
@@ -14,6 +14,17 @@
 //you can change this to whatever you want to use on your Tumblr
 your_pathname = 'tags';
 
+//these are used to determine how to set the font-sizes of the tags in the resulting list of tags
+//this way, the most used tags (with the highest usage-count) can have the largest font size
+//while the tags you barely use can have the smallest font size
+//you can set the boundaries between each category here, based on what suits you and your blog.
+
+threshold_barely = 5;		// tags used under this many times are considered barely-used
+threshold_sometimes = 12;	// tags used more than barely, but under this many times, are considered sometimes-used
+threshold_frequent = 25;	// tags used more than sometimes, but under this many times, are considered frequently-used
+threshold_normal = 50;		// tags used more than frequently, but under this many times, are considered normally-used
+// tags used more than normally will be considered always-used
+
 //global counters
 totalposts = 0;
 totaltags = 0;
@@ -123,16 +134,16 @@ function generateFlowers(tags)
         number = tags[t];
 		frequency = '';
 		
-		if (number < 5) {
+		if (number < threshold_barely) {
 		frequency = 'barely';
 		}
-		else if (number < 12) {
+		else if (number < threshold_sometimes) {
 		frequency = 'sometimes';
 		}
-		else if (number < 25) {
+		else if (number < threshold_frequent) {
 		frequency = 'frequent';
 		}
-		else if (number < 50) {
+		else if (number < threshold_normal) {
 		frequency = 'normal';
 		}
 		else {

--- a/tumblrtags.js
+++ b/tumblrtags.js
@@ -114,7 +114,7 @@ function generateFlowers(tags)
 	
 	if (sum < totaltags) { console.log('not ready ' + sum + "/" + total); return 'loading' + sum + "/" + total;}
 	
-	flower = "<ul id='tag_info' style='width:800px;'>";
+	flower = "<ul id='tag_info'>";
 	sortedTags = getSortedKeys(tags);
 	console.log(sortedTags);	//prints the sorted tags in descending order
 	

--- a/tumblrtags.js
+++ b/tumblrtags.js
@@ -89,6 +89,19 @@ function getTags(user_url)
 	}
 }
 
+function sanitizeTagForURL(tag_name)
+{
+	sanitized_tag_name = tag_name;
+
+	// replace spaces with hyphens
+	sanitized_tag_name = sanitized_tag_name.replace(/\s+/g, '-');
+	
+	// replace apostrophes with URL encoding
+	sanitized_tag_name = sanitized_tag_name.replace(/[']/g, '%27');
+	
+	return sanitized_tag_name;
+}
+
 //generate the pretty html that you'll use on your page
 function generateFlowers(tags)
 {
@@ -125,7 +138,9 @@ function generateFlowers(tags)
 		frequency = 'always';
 		}
 		
-		flower += "<li class='tagitem'><a href='/tagged/"+t.replace(/\s+/g, '-')+"' class='" + frequency + "'>"+ t + " " + number +"</a></li>";
+		tag_url = "/tagged/" + sanitizeTagForURL(t);
+		
+		flower += "<li class='tagitem'><a href='" + tag_url + "' class='" + frequency + "'>"+ t + " " + number + "</a></li>";
 	}
 	flower += "</ul>";	
 	


### PR DESCRIPTION
- Moved the code for turning spaces into dashes into a new sanitizeTagForURL function, and added the ability to also escape apostrophes (fixes Issue #2).
- The frequency thresholds are now variables near the top, to hopefully make them easier to tweak for users. 
- Tags will now appear on the page with the tag count in parentheses.
- Hard-coded list width removed (leaving to user's CSS)
- Eliminated redundant header from HTML template.